### PR TITLE
Make annotations and device name configurable.

### DIFF
--- a/deploy/example/aws/daemonset.yaml
+++ b/deploy/example/aws/daemonset.yaml
@@ -35,8 +35,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-            - name: WS_WG_DEVICE_NAME
-              value: 'wireguard.gcp'
+            - name: WS_LOCAL_CLUSTER_NAME
+              value: 'aws'
+            - name: WS_WATCH_CLUSTER_NAME
+              value: 'gcp'
             - name: WS_WG_LISTEN_PORT
               value: "51821"
           ports:

--- a/deploy/example/gcp/daemonset.yaml
+++ b/deploy/example/gcp/daemonset.yaml
@@ -35,8 +35,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-            - name: WS_WG_DEVICE_NAME
-              value: 'wireguard.aws'
+            - name: WS_LOCAL_CLUSTER_NAME
+              value: 'gcp'
+            - name: WS_WATCH_CLUSTER_NAME
+              value: 'aws'
             - name: WS_WG_DEVICE_MTU
               value: "1380"
             - name: WS_WG_LISTEN_PORT


### PR DESCRIPTION
Configure based on supplied cluster names for the local and the watch cluster.
That will allow running more than one wiresteward agents per kube node, each one
of which will be managing one wg device and a single route to the remote cluster